### PR TITLE
EVG-16165: Python version bump

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -139,7 +139,7 @@ tasks:
           directory: curatorbin
       - command: subprocess.exec
         params:
-          command: 'c:\\python39\\python.exe -m venv ./venv'
+          command: 'c:\\python310\\python.exe -m venv ./venv'
           directory: curatorbin
       - command: shell.exec
         params:

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -201,10 +201,8 @@ buildvariants:
   - name: windows
     display_name: Windows
     run_on:
-      - windows-64-vs2017-small
       - windows-64-vs2019-small
       - windows-64-vs2019-large
-      - windows-64-vs2017-large
     expansions:
       test_timeout: 15m
     tasks:


### PR DESCRIPTION
Boilerplate python version bump. 2017 versions of windows have 3.9, 2019 has 3.10 now (or maybe it always had it). I removed 2017 versions from allowable host types list and incremented the python executable's full path to python310. For some reason, all the other tests worked after I re-ran them.